### PR TITLE
Bug fix: overrideAA isn't always set.

### DIFF
--- a/extra-vs-spells.lua
+++ b/extra-vs-spells.lua
@@ -151,7 +151,10 @@ T.RemoveOverrideAA = {
     409,
 }
 
-if VenturePlan ~= nil and VenturePlan.overrideAA ~= nil then
+if VenturePlan ~= nil then
+    if not VenturePlan.overrideAA then
+        VenturePlan.overrideAA = {}
+    end
     for k,v in pairs(T.MoreSpells) do
         VenturePlan.KnownSpells[k] = v
     end
@@ -164,6 +167,6 @@ if VenturePlan ~= nil and VenturePlan.overrideAA ~= nil then
     for _,v in pairs(T.RemoveOverrideAA) do
         VenturePlan.overrideAA[v] = nil
     end
-else
-    message("You are running an undoctored version of VenturePlan. Instructions on how to make this addon work are at https://github.com/hythloday/VenturePlanSoDMissions")
+else 
+    message("You are running an undoctored version of VenturePlan. Instructions on how to make this addon work are at https://github.com/Divergentcurl/VenturePlanSoDMissions")
 end


### PR DESCRIPTION
overrideAA isn't always set, and was throwing a `nil` value error for me. Instantiating it if it doesn't exist fixes the issue.

Also, updated the URL reported to the user if they haven't patched their version.